### PR TITLE
Tables with fewer columns no longer holds empty space at the right side of the table.

### DIFF
--- a/src/components/DynamicTableManager.jsx
+++ b/src/components/DynamicTableManager.jsx
@@ -169,6 +169,7 @@ function DynamicTableContent({ defaultFormData = {}, location, user }) {
           editType={"fullRow"}
           onRowValueChanged={onRowValueChanged}
           onSelectionChanged={onSelectionChanged}
+          autoSizeStrategy={ {type: 'fitGridWidth'} }
         />
       </div>
       <div className="flex flex-row-reverse m-0 p-0">


### PR DESCRIPTION
Fixed the empty space in tables with fewer columns.

Closes #21